### PR TITLE
Fix manifest resource matches and update example text

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,14 +31,16 @@
     }
   ],
   "devtools_page": "devtools.html",
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "content.styles.css",
-        "icon-128.png",
-        "icon-34.png"
-      ],
-      "matches": []
-    }
-  ]
-}
+    "web_accessible_resources": [
+      {
+        "resources": [
+          "content.styles.css",
+          "icon-128.png",
+          "icon-34.png"
+        ],
+        "matches": [
+          "<all_urls>"
+        ]
+      }
+    ]
+  }

--- a/src/pages/Newtab/Newtab.jsx
+++ b/src/pages/Newtab/Newtab.jsx
@@ -9,7 +9,7 @@ const Newtab = () => {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
-          Edit <code>src/pages/Newtab/Newtab.js</code> and save to reload.
+          Edit <code>src/pages/Newtab/Newtab.jsx</code> and save to reload.
         </p>
         <a
           className="App-link"

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -9,7 +9,7 @@ const Popup = () => {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
-          Edit <code>src/pages/Popup/Popup.js</code> and save to reload.
+          Edit <code>src/pages/Popup/Popup.jsx</code> and save to reload.
         </p>
         <a
           className="App-link"


### PR DESCRIPTION
## Summary
- fix `web_accessible_resources` in `manifest.json`
- correct file references inside example pages

## Testing
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_68634b90a0dc832aa1f563f3d049b56e